### PR TITLE
Not able to run because JCenter does not host aapt2 anymore

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:4.0.0'
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
+        google()
     }
 }


### PR DESCRIPTION
Google repository should be used in `build.gradle` instead of JCenter, cf. https://stackoverflow.com/questions/50279792/

Also I changed gradle version to 4.0.0 in order to use `google()`.