### PR TITLE
Provide another english translation for the result view.

### DIFF
--- a/app/src/main/java/de/xskat/Translations.java
+++ b/app/src/main/java/de/xskat/Translations.java
@@ -15,7 +15,7 @@ public class Translations {
             {"Ramsch", "Ramsch"}, // XT_Ramsch
             {"Sortiere für Null", "Sort for Null"}, // XT_Sortiere_fuer_Null
             {"Sortiere normal", "Sort normally"}, // XT_Sortiere_normal
-            {"Gereizt bis: ", "You have bid: "}, // XT_Gereizt_bis
+            {"Gereizt bis", "It was bid"}, // XT_Gereizt_bis
             {"Androido", "Androido"}, // XT_Androido
             {"Androida", "Androida"}, // XT_Androida
             {"spielt", "plays"}, // XT_spielt

--- a/app/src/main/java/de/xskat/XSkat.java
+++ b/app/src/main/java/de/xskat/XSkat.java
@@ -1995,7 +1995,7 @@ public class XSkat extends Activity {
     }
 
     void initHandStr() {
-        setText(R.id.textGereiztHand, getTranslation(Translations.XT_Gereizt_bis) + reizValues[reizp]);
+        setText(R.id.textGereiztHand, getTranslation(Translations.XT_Gereizt_bis) + ": " + reizValues[reizp]);
     }
 
     void initVerdoppeltStr() {
@@ -2060,7 +2060,7 @@ public class XSkat extends Activity {
     }
 
     void initSpielStr() {
-        setText(R.id.textGereizt, getTranslation(Translations.XT_Gereizt_bis) + reizValues[reizp]);
+        setText(R.id.textGereizt, getTranslation(Translations.XT_Gereizt_bis) + ": " + reizValues[reizp]);
     }
 
     void initStichStr() {
@@ -2113,7 +2113,7 @@ public class XSkat extends Activity {
         if (GameType.isRamsch(trumpf)) {
             v.setText("");
         } else {
-            s = getTranslation(Translations.XT_Gereizt_bis) + reizValues[reizp];
+            s = getTranslation(Translations.XT_Gereizt_bis) + ": " + reizValues[reizp];
             v.setText(s);
         }
     }


### PR DESCRIPTION
"You have bid" can be wrong when a computer player has bid. So here is a more generic translation.

![Screenshot_1609355655](https://user-images.githubusercontent.com/37914724/103375943-a74bfb80-4adb-11eb-955e-c954394cba31.png)

@rnauber With this PR, I think you can create a new version of XSkat for Fdroid. 👍 